### PR TITLE
Export HTML from evernote instead of text.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,17 @@ const fse = require('fs-extra')
 const moment = require('moment')
 const fm = require('front-matter')
 const entities = require('entities')
-const enml2text = require('enml2text')
+var enml2html = require('enml2html') // use var for easy mock in mocha testing
 const debug = require('debug')('everblog-adaptor-hexo')
+const cheerio = require('cheerio')
+const format = require('string-format')
+const Promise = require('bluebird')
 
 module.exports = function* (data) {
   const dist = process.cwd() + '/source/_posts/'
   fse.emptyDirSync(dist)
 
-  data.posts.forEach(post => {
+  for(let post of data.posts){
     const defaultFrontMatter = {
       title: post.title,
       date: formatDate(post.created),
@@ -21,20 +24,65 @@ module.exports = function* (data) {
     }
     debug('content -> %j', post.content)
 
-    let contentMarkdown = entities.decodeHTML(enml2text(post.content))
+    let contentMarkdown = enml2html(post.content, post.resources, data.$webApiUrlPrefix, post.noteKey)
     debug('contentMarkdown -> %j', contentMarkdown)
 
-    let data = fm.parse(contentMarkdown)
-    _.merge(data.attributes, defaultFrontMatter)
-    contentMarkdown = fm.stringify(data)
+    let $ = cheerio.load(contentMarkdown)
+    // Download all images and update the src attribute.
+    const getNoteResource = Promise.promisify(data.noteStore.getResource, { context: data.noteStore })
+    if (post.resources) {
+      for (let res of post.resources) {
+        let resData = yield getNoteResource(res.guid, true, false, true, false)
+        var fileName = resData.attributes.fileName
+        if (!fileName) {
+          fileName = Date.now().toString()
+        }
+        // Some images don't have file name field.
+        // Make sure each of them has a name.
+        fileName = fileName.replace(/_/g, '')
+        const imgFile = format('/images/{}/{}', post.title, fileName)
+        fse.outputFileSync(format('{}/source/{}', process.cwd(), imgFile), new Buffer(resData.data.body), 'binary')
+        const hash = bodyHashToString(resData.data.bodyHash)
+        // Point src field to the resource's real location.
+        // This does work if you deploy it to your hexo server.
+        $(format('img[hash="{}"]', hash)).attr('src', imgFile)
+      }
+    }
 
-    const filename = dist + data.attributes.title + '.md'
+    // longdesc and alt field will make the HTML show the picture name on page.
+    // That is not expected for some inline pictures.
+    // Just remove them.
+    $('img').attr('longdesc', '')
+    $('img').attr('alt', '')
+    // Originally, they are inline-block, which will make the view is out of page scope.
+    // Making it as block will force everything in scope.
+    $('div').css('display', 'block')
+    contentMarkdown = $.html()
+
+    var info = fm.parse(contentMarkdown)
+    _.merge(info.attributes, defaultFrontMatter)
+    contentMarkdown = fm.stringify(info)
+
+    const filename = dist + info.attributes.title + '.html'
     fse.outputFileSync(filename, contentMarkdown)
-    debug('title -> %s, body -> %j', data.attributes.title, contentMarkdown)
-  })
+    debug('title -> %s, body -> %j', info.attributes.title, contentMarkdown)
+  }
   debug('build success!')
 }
 
 function formatDate(timestamp) {
   return moment(timestamp).format('YYYY/M/DD HH:mm:ss')
 }
+
+function bodyHashToString(bodyHash) {
+  let str = '';
+  for (let i in bodyHash) {
+    let hexStr = bodyHash[i].toString(16);
+    if (hexStr.length === 1) {
+      hexStr = '0' + hexStr;
+    }
+    str += hexStr;
+  }
+  return str;
+}
+

--- a/package.json
+++ b/package.json
@@ -10,13 +10,18 @@
     "hexo"
   ],
   "dependencies": {
+    "co": "^4.6.0",
     "debug": "^2.2.0",
-    "enml2text": "^0.1.1",
+    "enml2html": "^0.3.1",
     "entities": "^1.1.1",
     "front-matter": "git://github.com/nswbmw/front-matter.git#add_parse_and_stringify",
+    "fs": "0.0.1-security",
     "fs-extra": "^0.26.5",
     "lodash": "^4.6.1",
-    "moment": "^2.12.0"
+    "moment": "^2.12.0",
+    "rewire": "^2.5.2",
+    "should": "^11.2.1",
+    "string-format": "^0.5.0"
   },
   "author": {
     "name": "nswbmw",

--- a/test/hexo-adaptor.js
+++ b/test/hexo-adaptor.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const fs = require('fs')
+const should = require('should')
+const co = require('co')
+const cheerio = require('cheerio')
+const rewire = require("rewire");
+const fm = require('front-matter')
+const format = require('string-format')
+var processor = rewire('../index')
+
+describe('generate html blog post based notes data', function () {
+  it('note2html', function(){
+    const data ={
+      attributes: {
+        title: "test, blog title"
+      },
+      webApiUrlPrefix: "test url prefix",
+      noteStore: {
+        getResource: function(a,b,c,d,e,callback){
+          callback(null, resData)
+        }
+      },
+      posts: [
+        { // post with resources
+          title: "test note title",
+          created: 1498021041970,
+          updated: 1498021041970,
+          tags: [],
+          resources: [
+            { 
+              guid: '123456',
+            }
+          ],
+        },
+        { // post without resources
+          title: "test note title no resource",
+          created: 1498021041970,
+          updated: 1498021041970,
+          tags: [],
+          resources: null
+        }
+      ]
+    }
+    const resData = {
+      attributes: {
+        fileName: '__test_resource'
+      },
+      data: {
+        bodyHash: [0],
+        body: [12,34,56,78]
+      }
+    }
+
+    processor.__set__("enml2html", function(a, b){
+      if (b){ // has resource
+        return `<div><img alt='123' longdesc='123' hash='00' src='http://web.test.com'></img></div>`
+      }
+      else { // no resource
+        return `<div></div>`
+      }
+    });
+    const dist = process.cwd() + '/source/_posts/';
+    return (function(){
+      return co(function*(){
+        return yield processor(data)
+      })
+    }()).should.not.be.rejected()
+      .should.be.fulfilled().then(function(){
+        // verify
+        data.posts.forEach(post => {
+          let fileName = dist + post.title + '.html'
+          fs.existsSync(fileName).should.be.true()
+          let html = fs.readFileSync(fileName, 'utf-8')
+          fm.test(html).should.be.true()
+          let content = fm(html).body
+          let $ = cheerio.load(content)
+          $('img').should.exist
+          $('img').each(function(){
+            $(this).attr('longdesc').should.be.equal('')
+            $(this).attr('alt').should.be.equal('')
+            $(this).attr('src').should.startWith('/images/')
+            $(this).attr('src').indexOf('_').should.equal(-1)
+            fs.existsSync(format('{}/source/{}', process.cwd(), $(this).attr('src'))).should.be.true()
+          })
+        })
+      })
+  })
+})


### PR DESCRIPTION
Hi,
Exporting only text will lose most of the data if you are going to import post from your Evernote note. I leverage one of your other projects (enml2html) to do this work. It works well with my hexo server.

The functionalities include:
1.Export HTML of a note from Evernote. Download all image resource from that note and show them in img tag of that html. 
2.Add mocha test cases.